### PR TITLE
Update the `.env.sample` file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -32,7 +32,7 @@ ONCONOVA_SERVER_ANONYMIZATION_KEY="yqjO5WxiPA2cHavbWyDi76E6Mk7CbqP9"
 ONCONOVA_SERVER_ENCRYPTION_KEY="5u5]GprUHH;b_{%q%Hhwx_SnI5avgg"
 # Comma-separated list of hosts allowed to make HTTP requests to the server based on the HOST header 
 # (by default, ONCONOVA_SERVER_ADDRESS, ONCONOVA_CLIENT_WEBSERVER_ADDRESS, and ONCONOVA_DOCS_WEBSERVER_ADDRESS are allowed)
-ONCONOVA_SERVER_ALLOWED_HOSTS=https://localhost
+ONCONOVA_SERVER_ALLOWED_HOSTS=localhost
 # Comma-separated list of web-origins allowed to make cross-origin AJAX requests to the server
 # (by default, ONCONOVA_SERVER_ADDRESS, ONCONOVA_CLIENT_WEBSERVER_ADDRESS, and ONCONOVA_DOCS_WEBSERVER_ADDRESS are allowed)
 ONCONOVA_SERVER_CORS_ALLOWED_ORIGINS=https://localhost


### PR DESCRIPTION
This pull request updates the `.env.sample` file to streamline environment configuration and remove unused documentation settings. The main changes focus on simplifying Docker Compose setup and cleaning up obsolete configuration options.

Environment configuration updates:

* Changed the default Docker Compose file reference from `compose.prod.yml` to a more generic `compose.yml` for improved clarity for new users following the documentation.

Cleanup of obsolete settings:

* Removed the section for documentation webserver address (`ONCONOVA_DOCS_WEBSERVER_ADDRESS`) and its related comments, since this configuration is no longer needed.