### PR TITLE
Fix NeoplasticEntityForm filtering and state reset for entity relationships

### DIFF
--- a/client/src/app/features/forms/neoplastic-entity-form/neoplastic-entity-form.component.ts
+++ b/client/src/app/features/forms/neoplastic-entity-form/neoplastic-entity-form.component.ts
@@ -142,6 +142,7 @@ export class NeoplasticEntityFormComponent extends AbstractFormBase{
     const relatedPrimaryControl = this.form.get('relatedPrimary')
     if (this.#currentNeoplasticRelationship() === NeoplasticEntityRelationshipChoices.Primary) {
       relatedPrimaryControl?.removeValidators(Validators.required);
+      relatedPrimaryControl?.setValue(null);
     } else {
       relatedPrimaryControl?.addValidators(Validators.required);
     }  


### PR DESCRIPTION
This pull request makes targeted improvements to the `NeoplasticEntityFormComponent` to enhance form behavior and data filtering for neoplastic entity relationships. The main changes ensure that when editing or creating entities, the current entity is excluded from selectable related primaries and the form state is properly reset when switching relationship types.

* Fixes #172 

### Fixed

* The `relatedPrimaries` data loader now excludes the current entity from the list of selectable primary neoplastic entities by adding an `idNot` filter to the request avoiding the possibility of self-referencing when switching an existing `primary` to `metastatic`.
* When the neoplastic relationship is set to `primary` from any of the other options, the `relatedPrimary` form control is now cleared (set to `null`) preventing an invalid payload from being delivered leading to a database integrity error returning as a 500 HTTP error.