### PR TITLE
Ensure that the documentation workflow install server dev dependencies

### DIFF
--- a/.github/workflows/onconova-build-and-push.yml
+++ b/.github/workflows/onconova-build-and-push.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ../docs
-          pip install ../server
+          pip install ../server[dev]
 
       - name: Setup Git CLI user
         working-directory: ./docs-repo

--- a/.github/workflows/onconova-dev-docs.yml
+++ b/.github/workflows/onconova-dev-docs.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ../docs
-          pip install ../server
+          pip install ../server[dev]
 
       - name: Setup Git CLI user
         working-directory: ./docs-repo

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "onconova-docs"
-version = "1.0.0"
+version = "1.3.0"
 description = "Documentation for Onconova"
 license = "MIT"
 authors = [


### PR DESCRIPTION
This pull request makes minor updates to the documentation build process and versioning. The main changes are updating the development dependencies used during CI and incrementing the documentation package version.

### Changed 
  - Updated the installation command in both `.github/workflows/onconova-build-and-push.yml` and `.github/workflows/onconova-dev-docs.yml` to use `pip install ../server[dev]` instead of `pip install ../server`, ensuring development dependencies are installed during CI runs.