### PR TITLE
Raise well documented 422 HTTP errors when a terminology concept is not found in a many-to-many relation

### DIFF
--- a/server/onconova/core/serialization/base.py
+++ b/server/onconova/core/serialization/base.py
@@ -15,6 +15,7 @@ from django.contrib.postgres.fields import BigIntegerRangeField, DateRangeField
 from django.db import transaction
 from django.db.models import Field as DjangoField
 from django.db.models import Model as DjangoModel
+from django.core.exceptions import ObjectDoesNotExist
 from ninja import Schema
 from ninja.schema import DjangoGetter as BaseDjangoGetter
 from pydantic import BaseModel as PydanticBaseModel, ValidationError
@@ -361,13 +362,19 @@ class BaseSchema(
                 related_model: Type[DjangoModel] = orm_field.related_model
                 if orm_field.many_to_many:
                     if issubclass(related_model, CodedConcept):
+                        m2m_relations[orm_field.name] = []
                         # Collect all related instances
-                        m2m_relations[orm_field.name] = [
-                            related_model.objects.get(
-                                code=concept.get("code"), system=concept.get("system")
-                            )
-                            for concept in data or []
-                        ]
+                        for concept in data or []:
+                            try:
+                                m2m_relations[orm_field.name].append(
+                                    related_model.objects.get(
+                                        code=concept.get("code"), system=concept.get("system")
+                                    )
+                                )
+                            except related_model.DoesNotExist:
+                                raise CodedConceptDoesNotExist(
+                                    f"Got a unsupported or invalid CodedConcept with code '{concept.get('code')}' and system '{concept.get('system')}' for {camel_to_snake(related_model.__name__).replace('_', ' ')} valueset."
+                                )
                     elif issubclass(related_model, User):
                         # For users. query the database via the username
                         m2m_relations[orm_field.name] = [


### PR DESCRIPTION
This pull request improves the error handling and robustness of the many-to-many serialization logic for `CodedConcept` relations in the `model_dump_django` function. Specifically, it ensures that invalid or unsupported `CodedConcept` codes are caught and reported with a clear exception, rather than failing silently or causing generic errors.

### Fixed
* In `server/onconova/core/serialization/base.py`, the many-to-many relation processing for `CodedConcept` now attempts to fetch each related instance individually and raises a `CodedConceptDoesNotExist` exception with a detailed message if a code/system pair is invalid, improving debugging and data integrity.