### PR TITLE
Ensure periods are (de)serialized with inclusive upper bounds

### DIFF
--- a/server/onconova/core/schemas.py
+++ b/server/onconova/core/schemas.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import Any, Dict, Generic, List, TypeVar, Union
 
 from ninja import Schema
@@ -169,7 +169,7 @@ class Range(Schema):
         """
         Converts this Range schema into a Python tuple.
         """
-        return (self.start, self.end)
+        return PostgresRange(self.start, self.end, bounds="[)")
 
 class Period(Schema):
     """
@@ -199,11 +199,14 @@ class Period(Schema):
         elif isinstance(period_obj, tuple):
             return {"start": period_obj[0], "end": period_obj[1]}
         elif isinstance(period_obj, PostgresRange):
-            return {"start": period_obj.lower, "end": period_obj.upper}
+            upper = period_obj.upper
+            if upper is not None and not period_obj.upper_inc:
+                upper = upper - timedelta(days=1)
+            return {"start": period_obj.lower, "end": upper}
         return obj
 
-    def to_range(self) -> tuple:
+    def to_range(self) -> PostgresRange:
         """
         Converts this Period schema into a Python tuple of dates.
         """
-        return (self.start, self.end)
+        return PostgresRange(self.start, self.end, bounds="[]")

--- a/server/onconova/core/serialization/base.py
+++ b/server/onconova/core/serialization/base.py
@@ -15,6 +15,7 @@ from django.contrib.postgres.fields import BigIntegerRangeField, DateRangeField
 from django.db import transaction
 from django.db.models import Field as DjangoField
 from django.db.models import Model as DjangoModel
+from psycopg.types.range import Range as PostgresRange
 from django.core.exceptions import ObjectDoesNotExist
 from ninja import Schema
 from ninja.schema import DjangoGetter as BaseDjangoGetter
@@ -446,10 +447,15 @@ class BaseSchema(
                         orm_field.measurement(**{data.get("unit"): data.get("value")}),
                     )
                 elif (
-                    isinstance(orm_field, (DateRangeField, BigIntegerRangeField))
+                    isinstance(orm_field, BigIntegerRangeField)
                     and data is not None
                 ):
-                    setattr(instance, orm_field.name, (data["start"], data["end"]))
+                    setattr(instance, orm_field.name, PostgresRange(data["start"], data["end"], bounds="[)"))
+                elif (
+                    isinstance(orm_field, DateRangeField)
+                    and data is not None
+                ):
+                    setattr(instance, orm_field.name, PostgresRange(data["start"], data["end"], bounds="[]"))
                 else:
                     # Otherwise simply handle all other non-relational fields
                     setattr(instance, orm_field.name, data)

--- a/server/onconova/interoperability/parsers.py
+++ b/server/onconova/interoperability/parsers.py
@@ -269,7 +269,7 @@ class BundleParser:
             instance=instance,
             **fields,
             external_source=resource.externalSource or "Onconova", # type: ignore 
-            external_source_id=resourceId,
+            external_source_id=resource.externalSourceId or resourceId, # type: ignore 
         )
         # Delete the create event that just happened
         orm_instance.events.latest("pgh_created_at").delete()


### PR DESCRIPTION
This pull request updates how date and numeric range fields are handled throughout the codebase to ensure consistent use of `PostgresRange` objects and corrects period serialization logic. 

### Fixed 
* Fixed (de)serialization logic to ensure that `DateRangeField` model fields are (de)serialized with inclusive upper bounds. 
