### PR TITLE
Ensure that `externalSourceId` is correctly serialized and delivered over the API

### DIFF
--- a/server/onconova/core/serialization/base.py
+++ b/server/onconova/core/serialization/base.py
@@ -44,11 +44,13 @@ _DjangoModel = TypeVar("_DjangoModel", bound=DjangoModel)
 
 
 def get_orm_alias(name):
+    EXCEPTIONS = {"external_source_id"}
     name = camel_to_snake(name)
-    if name.endswith("_id"):
-        name = name.replace("_id", "")
-    elif name.endswith("_ids"):
-        name = name.replace("_ids", "")
+    if name not in EXCEPTIONS:
+        if name.endswith("_id"):
+            name = name.replace("_id", "")
+        elif name.endswith("_ids"):
+            name = name.replace("_ids", "")
     return name
 
 


### PR DESCRIPTION
This PR makes a small adjustment to the `get_orm_alias` function in `server/onconova/core/serialization/base.py`. The change introduces an exception for the field name `"external_source_id"`, so it will not be altered by the logic that removes the `_id` suffix from field names.

### Fixed 
- Ensured that `externalSourceId` is correctly serialized and delivered over the API. Fixes #200