### PR TITLE
Fix command in documentation deployment workflows to use `git pull` instead of `git fetch`

### DIFF
--- a/.github/workflows/onconova-build-and-push.yml
+++ b/.github/workflows/onconova-build-and-push.yml
@@ -114,6 +114,6 @@ jobs:
         working-directory: ./docs-repo
         run: |
           npx @compodoc/compodoc@1.1.26 -p ../client/tsconfig.doc.json -d ../docs/src/compodoc/ -y ../docs/src/assets/css/compodoc/ --hideGenerator --theme material
-          git fetch origin main 
+          git pull origin main
           mike deploy --push -b main --config-file ../docs/mkdocs.yml --update-aliases $(echo "${{ github.event.release.tag_name }}" | grep -oP '^\d+\.\d+') latest
           mike set-default -b main --config-file ../docs/mkdocs.yml latest

--- a/.github/workflows/onconova-dev-docs.yml
+++ b/.github/workflows/onconova-dev-docs.yml
@@ -68,5 +68,5 @@ jobs:
         working-directory: ./docs-repo
         run: |
           npx @compodoc/compodoc@1.1.26 -p ../client/tsconfig.doc.json -d ../docs/src/compodoc/ -y ../docs/src/assets/css/compodoc/ --hideGenerator --theme material
-          git fetch origin main
+          git pull origin main
           mike deploy --push -b main --config-file ../docs/mkdocs.yml dev


### PR DESCRIPTION
This pull request updates the documentation deployment workflows to ensure the local documentation repository is always up to date before deploying. The main change is replacing `git fetch` with `git pull` in both the production and development documentation workflows, ensuring that the latest changes from the `main` branch are incorporated before running deployment commands.

### Fixed 
* Changed `git fetch origin main` to `git pull origin main` to ensure the local `docs-repo` has the latest changes from the `main` branch before deploying development documentation.