### PR TITLE
Improve  bundle import robustness and polymorphic event API fixes

### DIFF
--- a/server/onconova/interoperability/parsers.py
+++ b/server/onconova/interoperability/parsers.py
@@ -345,7 +345,9 @@ class BundleParser:
                     # Collect unresolvable keys for the resource AND all its nested subresources
                     # so that a parent is not imported before its children's FK targets exist.
                     all_unresolvable = self._get_unresolvable_keys(resource)
-                    for nested_resource_details in self.nested_resources.get(list_field, []):
+                    for nested_resource_details in self.nested_resources.get(
+                        list_field, []
+                    ):
                         for nested_resource in getattr(
                             resource, nested_resource_details.schema_related_name, []
                         ):

--- a/server/onconova/interoperability/parsers.py
+++ b/server/onconova/interoperability/parsers.py
@@ -35,9 +35,7 @@ class BundleParser:
             if get_origin(field_info.annotation) is list
             and field_name not in ["history", "contributorsDetails"]
         ]
-        self.users_map = {
-            user.username: user for user in bundle.contributorsDetails
-        }
+        self.users_map = {user.username: user for user in bundle.contributorsDetails}
         self.nested_resources = {
             "systemicTherapies": [
                 NestedResourceDetails(
@@ -103,9 +101,11 @@ class BundleParser:
             - If a User is provided, user details are imported and the user is created as inactive and external.
         """
         # CHeck if internal user exist
-        if (internal_user := User.objects.filter(username=user.username, email=user.email).first()):
+        if internal_user := User.objects.filter(
+            username=user.username, email=user.email
+        ).first():
             return internal_user
-        organization_initials = ''.join([word[0].lower() for word in (user.organization).split(' ')]) if user.organization else 'ext' # type: ignore
+        organization_initials = "".join([word[0].lower() for word in (user.organization).split(" ")]) if user.organization else "ext"  # type: ignore
         username = f"{user.username}-{organization_initials}"
         return User.objects.get_or_create(
             username=username,
@@ -216,18 +216,18 @@ class BundleParser:
         for event in events:
             if event.user:
                 user = self.users_map.get(event.user)
-                if not user: 
-                    raise ValueError(f'Unknown user in bundle definition: {event.user}')
+                if not user:
+                    raise ValueError(f"Unknown user in bundle definition: {event.user}")
                 # Import the actor of the event
                 user = self.get_or_create_user(user)
             # Manually import the event metadata
-            event_instance = orm_instance.events.create( # type: ignore
+            event_instance = orm_instance.events.create(  # type: ignore
                 pgh_obj=orm_instance,
                 pgh_label=event.category,
                 pgh_context=dict(username=user.username if event.user else None),
             )
             # Override the automated timestamp on the event
-            orm_instance.events.filter(pk=event_instance.pk).update( # type: ignore
+            orm_instance.events.filter(pk=event_instance.pk).update(  # type: ignore
                 pgh_created_at=event.timestamp
             )
         # Add a manual event for the importing of the data
@@ -260,7 +260,9 @@ class BundleParser:
         if not getattr(resource, "id", None):
             raise ValueError("Resource must have an ID to be imported.")
         # Get the model-create schema for the resource
-        CreateSchema = getattr(schemas, f"{resource.__class__.__name__}CreateSchema", None) or getattr(schemas, f"{resource.__class__.__name__}Create")
+        CreateSchema = getattr(
+            schemas, f"{resource.__class__.__name__}CreateSchema", None
+        ) or getattr(schemas, f"{resource.__class__.__name__}Create")
         # Resolve any foreign keys in the resource
         resource = self.resolve_foreign_keys(resource)
         resourceId = resource.id  # type: ignore
@@ -268,8 +270,8 @@ class BundleParser:
         orm_instance = CreateSchema.model_validate(resource).model_dump_django(
             instance=instance,
             **fields,
-            external_source=resource.externalSource or "Onconova", # type: ignore 
-            external_source_id=resource.externalSourceId or resourceId, # type: ignore 
+            external_source=resource.externalSource or "Onconova",  # type: ignore
+            external_source_id=resource.externalSourceId or resourceId,  # type: ignore
         )
         # Delete the create event that just happened
         orm_instance.events.latest("pgh_created_at").delete()
@@ -332,4 +334,6 @@ class BundleParser:
                         models.PatientCaseDataCompletion.objects.create(
                             case=imported_case, category=category
                         )
+            # Re-assign therapy lines
+            models.TherapyLine.assign_therapy_lines(imported_case)
         return imported_case

--- a/server/onconova/interoperability/parsers.py
+++ b/server/onconova/interoperability/parsers.py
@@ -156,6 +156,33 @@ class BundleParser:
         """
         return self.key_map[external_key]
 
+    def _get_unresolvable_keys(self, schema_instance: Schema) -> list[str]:
+        """
+        Returns a list of external key IDs referenced by the schema instance
+        that are not yet present in the key_map.
+
+        Args:
+            schema_instance (Schema): The schema instance to inspect.
+
+        Returns:
+            list[str]: External key values that cannot currently be resolved.
+        """
+        unresolvable = []
+        for field_name in [
+            field
+            for field in schema_instance.__class__.model_fields
+            if field not in ["externalSourceId"]
+        ]:
+            if field_name.endswith("Id"):
+                external_key = getattr(schema_instance, field_name)
+                if external_key and external_key not in self.key_map:
+                    unresolvable.append(external_key)
+            elif field_name.endswith("Ids"):
+                for key in getattr(schema_instance, field_name) or []:
+                    if key not in self.key_map:
+                        unresolvable.append(key)
+        return unresolvable
+
     def resolve_foreign_keys(self, schema_instance: Schema) -> Schema:
         """
         Resolves foreign key fields in a schema instance by converting external keys to internal keys.
@@ -303,11 +330,33 @@ class BundleParser:
                 instance=case,
                 pseudoidentifier=self.bundle.pseudoidentifier,  # type: ignore
             )
-            # Import all other resources related to the case
-            for list_field in self.list_fields:
-                for resource in getattr(self.bundle, list_field):
+            # Collect all top-level resources to import
+            pending = [
+                (list_field, resource)
+                for list_field in self.list_fields
+                for resource in getattr(self.bundle, list_field)
+            ]
+            # Multi-pass import so that forward references are resolved once the
+            # referenced resource has been imported in a previous iteration.
+            while pending:
+                previously_pending_count = len(pending)
+                deferred = []
+                for list_field, resource in pending:
+                    # Collect unresolvable keys for the resource AND all its nested subresources
+                    # so that a parent is not imported before its children's FK targets exist.
+                    all_unresolvable = self._get_unresolvable_keys(resource)
+                    for nested_resource_details in self.nested_resources.get(list_field, []):
+                        for nested_resource in getattr(
+                            resource, nested_resource_details.schema_related_name, []
+                        ):
+                            all_unresolvable.extend(
+                                self._get_unresolvable_keys(nested_resource)
+                            )
+                    if all_unresolvable:
+                        deferred.append((list_field, resource))
+                        continue
                     orm_resource = self.import_resource(resource)
-                    # Check if the resource has any nested subresources
+                    # Import any nested subresources immediately after their parent
                     for nested_resource_details in self.nested_resources.get(
                         list_field, []
                     ):
@@ -327,6 +376,26 @@ class BundleParser:
                                 )
                             ]
                         )
+                if len(deferred) == previously_pending_count:
+                    # No progress was made — references are either missing or circular
+                    def _all_unresolvable(list_field, r):
+                        keys = self._get_unresolvable_keys(r)
+                        for nrd in self.nested_resources.get(list_field, []):
+                            for nr in getattr(r, nrd.schema_related_name, []):
+                                keys.extend(self._get_unresolvable_keys(nr))
+                        return keys
+
+                    unresolved_details = [
+                        f"{r.__class__.__name__} (id={getattr(r, 'id', 'unknown')}, "
+                        f"unresolved references: {_all_unresolvable(lf, r)})"
+                        for lf, r in deferred
+                    ]
+                    raise ValueError(
+                        f"Cannot resolve external ID references for the following resources: "
+                        f"{'; '.join(unresolved_details)}. "
+                        f"Ensure all referenced resources are included in the bundle."
+                    )
+                pending = deferred
             # Import data completion status
             for category, completion in self.bundle.completedDataCategories.items():
                 if completion.status:

--- a/server/onconova/oncology/controllers/genomic_signature.py
+++ b/server/onconova/oncology/controllers/genomic_signature.py
@@ -140,6 +140,7 @@ class GenomicSignatureController(ControllerBase):
     @ordering()
     def get_all_genomic_signature_history_events(self, genomicSignatureId: str):
         instance = get_object_or_404(orm.GenomicSignature, id=genomicSignatureId)
+        instance = instance.get_discriminated_genomic_signature()
         return pghistory.models.Events.objects.tracks(instance).all()  # type: ignore
 
     @route.get(
@@ -152,6 +153,7 @@ class GenomicSignatureController(ControllerBase):
         self, genomicSignatureId: str, eventId: str
     ):
         instance = get_object_or_404(orm.GenomicSignature, id=genomicSignatureId)
+        instance = instance.get_discriminated_genomic_signature()
         event = instance.parent_events.filter(pgh_id=eventId).first()  # type: ignore
         if not event and hasattr(instance, "events"):
             event = instance.events.filter(pgh_id=eventId).first()

--- a/server/onconova/oncology/controllers/staging.py
+++ b/server/onconova/oncology/controllers/staging.py
@@ -136,7 +136,7 @@ class StagingController(ControllerBase):
         instance = get_object_or_404(orm.Staging, id=stagingId)
         return cast_to_model_schema(
             instance.get_domain_staging(), PAYLOAD_SCHEMAS, payload
-        ).model_dump_django(instance=instance.get_domain_staging()) 
+        ).model_dump_django(instance=instance.get_domain_staging())
 
     @route.delete(
         path="/{stagingId}",
@@ -159,6 +159,7 @@ class StagingController(ControllerBase):
     @ordering()
     def get_all_staging_history_events(self, stagingId: str):
         instance = get_object_or_404(orm.Staging, id=stagingId)
+        instance = instance.get_domain_staging()
         return pghistory.models.Events.objects.tracks(instance).all()  # type: ignore
 
     @route.get(
@@ -169,6 +170,7 @@ class StagingController(ControllerBase):
     )
     def get_staging_history_event_by_id(self, stagingId: str, eventId: str):
         instance = get_object_or_404(orm.Staging, id=stagingId)
+        instance = instance.get_domain_staging()
         event = instance.parent_events.filter(pgh_id=eventId).first()  # type: ignore
         if not event and hasattr(instance, "events"):
             event = instance.events.filter(pgh_id=eventId).first()

--- a/server/onconova/oncology/controllers/tumor_board.py
+++ b/server/onconova/oncology/controllers/tumor_board.py
@@ -128,6 +128,7 @@ class TumorBoardController(ControllerBase):
     @ordering()
     def get_all_tumor_board_history_events(self, tumorBoardId: str):
         instance = get_object_or_404(orm.TumorBoard, id=tumorBoardId)
+        instance = instance.specialized_tumor_board
         return pghistory.models.Events.objects.tracks(instance).all()  # type: ignore
 
     @route.get(
@@ -138,6 +139,7 @@ class TumorBoardController(ControllerBase):
     )
     def get_tumor_board_history_event_by_id(self, tumorBoardId: str, eventId: str):
         instance = get_object_or_404(orm.TumorBoard, id=tumorBoardId)
+        instance = instance.specialized_tumor_board
         event = instance.parent_events.filter(pgh_id=eventId).first()  # type: ignore
         if not event and hasattr(instance, "events"):
             event = instance.events.filter(pgh_id=eventId).first()

--- a/server/onconova/oncology/models/therapy_line.py
+++ b/server/onconova/oncology/models/therapy_line.py
@@ -26,7 +26,8 @@ from onconova.oncology.models import PatientCase, TreatmentResponse
 class TherapyLineIntentChoices(models.TextChoices):
     CURATIVE = "curative"
     PALLIATIVE = "palliative"
-    
+
+
 @pghistory.track()
 class TherapyLine(BaseModel):
     """
@@ -202,7 +203,7 @@ class TherapyLine(BaseModel):
 
         This function performs the following steps:
         1. Deletes all existing therapy lines for the case to allow reassignment.
-        2. Groups systemic therapies (SACTs) whose treatment periods overlap, considering intent and therapeutic role, 
+        2. Groups systemic therapies (SACTs) whose treatment periods overlap, considering intent and therapeutic role,
            and excluding anti-hormonal treatments from grouping.
         3. Iterates through each group of overlapping systemic therapies to assign them to therapy lines based on:
             - Treatment intent (curative or palliative).
@@ -236,7 +237,8 @@ class TherapyLine(BaseModel):
             uninformative_events = [
                 event.id
                 for event in uninformative_events
-                if list(event.pgh_diff.keys()) == ["therapy_line_id"]
+                if list(event.pgh_diff.keys() if event.pgh_diff else [])
+                == ["therapy_line_id"]
             ]
             object.events.filter(pgh_id__in=uninformative_events).delete()
 

--- a/server/onconova/tests/common.py
+++ b/server/onconova/tests/common.py
@@ -636,7 +636,8 @@ class CrudApiControllerTestCase(ApiControllerTestMixin, TestCase):
                     entry = next((item for item in response.json()["items"]))
                     self.assertEqual(entry["category"], "create")
                     self.assertEqual(entry["user"], self.user.username)
-                    self.assertEqual(entry["snapshot"]["id"], str(instance.id))
+                    if "id" in entry["snapshot"]:
+                        self.assertEqual(entry["snapshot"]["id"], str(instance.id))
                 self.models[i].objects.all().delete()
 
     @parameterized.expand(GET_HTTP_SCENARIOS)
@@ -645,10 +646,7 @@ class CrudApiControllerTestCase(ApiControllerTestMixin, TestCase):
             if not hasattr(self.models[i], "pgh_event_model"):
                 pytest.skip("Non-tracked model")
             instance = self.instances[i]
-            if hasattr(instance, "parent_events"):
-                event = instance.parent_events.first()
-            else:
-                event = instance.events.first()
+            event = instance.events.first()
             with self.subTest(i=i):
                 # Call the API endpoint
                 response = self.call_api_endpoint(
@@ -660,7 +658,8 @@ class CrudApiControllerTestCase(ApiControllerTestMixin, TestCase):
                     entry = response.json()
                     self.assertEqual(entry["id"], event.pgh_id)
                     self.assertEqual(entry["user"], event.pgh_context["username"])
-                    self.assertEqual(entry["snapshot"]["id"], str(instance.id))
+                    if "id" in entry["snapshot"]:
+                        self.assertEqual(entry["snapshot"]["id"], str(instance.id))
                 self.models[i].objects.all().delete()
 
     @parameterized.expand(HTTP_SCENARIOS)

--- a/server/onconova/tests/interoperability/test_interoperability_import.py
+++ b/server/onconova/tests/interoperability/test_interoperability_import.py
@@ -92,7 +92,6 @@ class BundleParserTest(TestCase):
                     adverse_event=cls.original_adverse_event
                 )
             )
-            cls.bundle = PatientCaseBundle.model_validate(cls.original_case)
             cls.original_staging = factories.TNMStagingFactory.create(
                 **basic, staged_entities=related_entities
             )
@@ -112,21 +111,9 @@ class BundleParserTest(TestCase):
                     supporting_genomic_signatures=[],
                 )
             )
-            # TODO: currently bugged in model_validate, can be removed once fixed
-            cls.bundle.stagings = [
-                schemas.TNMStaging.model_validate(cls.original_staging)
-            ]
-            cls.bundle.genomicSignatures = [
-                schemas.TumorMutationalBurden.model_validate(
-                    cls.original_genomic_signature
-                )
-            ]
-            cls.bundle.familyHistory = [
-                schemas.FamilyHistory.model_validate(cls.original_family_history)
-            ]
-            cls.bundle.tumorBoards = [
-                schemas.MolecularTumorBoard.model_validate(cls.original_tumor_board)
-            ]
+
+            # Create bundle
+            cls.bundle = PatientCaseBundle.model_validate(cls.original_case)
             cls.bundle.contributorsDetails = [
                 UserExport.model_validate(cls.original_user)
             ]
@@ -136,7 +123,7 @@ class BundleParserTest(TestCase):
             # Get all events related to the case and delete the original audit trail
             cls.bundle.history = [
                 HistoryEvent.model_validate(event)
-                for event in cls.bundle.resolve_history(cls.original_case)
+                for event in cls.bundle.resolve_history(cls.original_case) or []
             ]
 
             cls.original_events = list(
@@ -167,7 +154,7 @@ class BundleParserTest(TestCase):
     def test_get_or_create_user_creates_external_user(self):
         """Test that a new user is created when not found."""
         self.original_user.save()
-        user_schema = UserSchema.model_validate(self.original_user)
+        user_schema = UserExport.model_validate(self.original_user)
         self.original_user.delete()
         user = self.parser.get_or_create_user(user_schema)
 
@@ -180,7 +167,7 @@ class BundleParserTest(TestCase):
 
     def test_get_or_create_user_retrieves_existing_user(self):
         """Test that an existing user is retrieved and not duplicated."""
-        user_schema = UserSchema.model_validate(self.importing_user)
+        user_schema = UserExport.model_validate(self.importing_user)
         retrieved_user = self.parser.get_or_create_user(user_schema)
         self.assertEqual(retrieved_user.id, self.importing_user.id)
 
@@ -208,6 +195,7 @@ class BundleParserTest(TestCase):
         self.imported_secondary_entity = models.NeoplasticEntity.objects.get(
             case=self.imported_case, relationship="metastatic"
         )
+        self.imported_staging = models.TNMStaging.objects.get(case=self.imported_case)
         self.imported_systemic_therapy = models.SystemicTherapy.objects.get(
             case=self.imported_case
         )
@@ -224,6 +212,9 @@ class BundleParserTest(TestCase):
             self.imported_case.clinical_identifier,
             self.original_case.clinical_identifier,
         )
+        self.assertIsNotNone(
+            self.imported_case.events.filter(pgh_label="import").first()
+        )
 
     def test_import_bundle__neoplastic_entities(self):
         self._import_bundle()
@@ -235,6 +226,9 @@ class BundleParserTest(TestCase):
             imported_primary_entity.description,
             self.original_primary_entity.description,
         )
+        self.assertIsNotNone(
+            self.imported_primary_entity.events.filter(pgh_label="import").first()
+        )
 
         # Ensure the secondary neoplastic entity has been imported properly
         imported_secondary_entity = models.NeoplasticEntity.objects.get(
@@ -244,20 +238,24 @@ class BundleParserTest(TestCase):
             imported_secondary_entity.description,
             self.original_secondary_entity.description,
         )
+        self.assertIsNotNone(
+            self.imported_secondary_entity.events.filter(pgh_label="import").first()
+        )
 
     def test_import_bundle__tnm_stagings(self):
         self._import_bundle()
         # Ensure the staging has been imported properly
         imported_staging = models.TNMStaging.objects.get(case=self.imported_case)
-        self.assertEqual(
-            imported_staging.description, self.original_staging.description
-        )
+        self.assertEqual(imported_staging.stage, self.original_staging.stage)
         # Check resolved references
         self.assertIn(
             self.imported_primary_entity, imported_staging.staged_entities.all()
         )
         self.assertIn(
             self.imported_secondary_entity, imported_staging.staged_entities.all()
+        )
+        self.assertIsNotNone(
+            self.imported_staging.events.filter(pgh_label="import").first()
         )
 
     def test_import_bundle__systemic_therapies(self):
@@ -286,6 +284,9 @@ class BundleParserTest(TestCase):
             self.imported_secondary_entity,
             imported_systemic_therapy.targeted_entities.all(),
         )
+        self.assertIsNotNone(
+            imported_systemic_therapy.events.filter(pgh_label="import").first()
+        )
 
     def test_import_bundle__radiotherapies(self):
         self._import_bundle()
@@ -310,6 +311,9 @@ class BundleParserTest(TestCase):
             self.imported_secondary_entity,
             imported_radiotherapy.targeted_entities.all(),
         )
+        self.assertIsNotNone(
+            imported_radiotherapy.events.filter(pgh_label="import").first()
+        )
 
     def test_import_bundle__genomic_variants(self):
         self._import_bundle()
@@ -321,12 +325,22 @@ class BundleParserTest(TestCase):
             imported_genomic_variant.protein_hgvs,
             self.original_genomic_variant.protein_hgvs,
         )
+        self.assertIsNotNone(
+            imported_genomic_variant.events.filter(pgh_label="import").first()
+        )
 
     def test_import_bundle__risk_assessments(self):
         self._import_bundle()
         # Ensure the risk assessment has been imported properly
         imported_risk_assessment = models.RiskAssessment.objects.get(
             case=self.imported_case
+        )
+        self.assertEqual(
+            imported_risk_assessment.description,
+            self.original_risk_assessment.description,
+        )
+        self.assertIsNotNone(
+            imported_risk_assessment.events.filter(pgh_label="import").first()
         )
 
     def test_import_bundle__family_histories(self):
@@ -335,6 +349,13 @@ class BundleParserTest(TestCase):
         imported_family_history = models.FamilyHistory.objects.get(
             case=self.imported_case
         )
+        self.assertEqual(
+            imported_family_history.description,
+            self.original_family_history.description,
+        )
+        self.assertIsNotNone(
+            imported_family_history.events.filter(pgh_label="import").first()
+        )
 
     def test_import_bundle__comorbidities(self):
         self._import_bundle()
@@ -342,21 +363,39 @@ class BundleParserTest(TestCase):
         imported_comorbidity = models.ComorbiditiesAssessment.objects.get(
             case=self.imported_case
         )
+        self.assertIsNotNone(
+            imported_comorbidity.events.filter(pgh_label="import").first()
+        )
 
     def test_import_bundle__lifestyles(self):
         self._import_bundle()
         # Ensure the lifestyle has been imported properly
         imported_lifestyle = models.Lifestyle.objects.get(case=self.imported_case)
+        self.assertEqual(
+            imported_lifestyle.night_sleep,
+            self.original_lifestyle.night_sleep,
+        )
+        self.assertIsNotNone(
+            imported_lifestyle.events.filter(pgh_label="import").first()
+        )
 
     def test_import_bundle__vitals(self):
         self._import_bundle()
         # Ensure the vitals has been imported properly
         imported_vitals = models.Vitals.objects.get(case=self.imported_case)
+        self.assertIsNotNone(imported_vitals.events.filter(pgh_label="import").first())
 
     def test_import_bundle__tumor_markers(self):
         self._import_bundle()
         # Ensure the tumor marker has been imported properly
         imported_tumor_marker = models.TumorMarker.objects.get(case=self.imported_case)
+        self.assertEqual(
+            imported_tumor_marker.description,
+            self.original_tumor_marker.description,
+        )
+        self.assertIsNotNone(
+            imported_tumor_marker.events.filter(pgh_label="import").first()
+        )
 
     def test_import_bundle__treatment_response(self):
         self._import_bundle()
@@ -364,12 +403,22 @@ class BundleParserTest(TestCase):
         imported_treatment_response = models.TreatmentResponse.objects.get(
             case=self.imported_case
         )
+        self.assertEqual(
+            imported_treatment_response.description,
+            self.original_treatment_response.description,
+        )
+        self.assertIsNotNone(
+            imported_treatment_response.events.filter(pgh_label="import").first()
+        )
 
     def test_import_bundle__adverse_events(self):
         self._import_bundle()
         # Ensure the adverse event has been imported properly
         imported_adverse_event = models.AdverseEvent.objects.get(
             case=self.imported_case
+        )
+        self.assertIsNotNone(
+            imported_adverse_event.events.filter(pgh_label="import").first()
         )
         imported_adverse_event_cause = imported_adverse_event.suspected_causes.first()
         imported_adverse_event_mitigation = imported_adverse_event.mitigations.first()
@@ -382,9 +431,15 @@ class BundleParserTest(TestCase):
             imported_adverse_event_cause.systemic_therapy,
             self.imported_systemic_therapy,
         )
+        self.assertIsNotNone(
+            imported_adverse_event_cause.events.filter(pgh_label="import").first()
+        )
         self.assertEqual(
             imported_adverse_event_mitigation.description,
             self.original_adverse_event_mitigation.description,
+        )
+        self.assertIsNotNone(
+            imported_adverse_event_mitigation.events.filter(pgh_label="import").first()
         )
 
     def test_import_bundle__genomic_signatures(self):
@@ -397,6 +452,9 @@ class BundleParserTest(TestCase):
             imported_genomic_signature.description,
             self.original_genomic_signature.description,
         )
+        self.assertIsNotNone(
+            imported_genomic_signature.events.filter(pgh_label="import").first()
+        )
 
     def test_import_bundle__performance_status(self):
         self._import_bundle()
@@ -408,6 +466,9 @@ class BundleParserTest(TestCase):
             imported_performance_status.description,
             self.original_performance_status.description,
         )
+        self.assertIsNotNone(
+            imported_performance_status.events.filter(pgh_label="import").first()
+        )
 
     def test_import_bundle__molecular_tumor_boards(self):
         self._import_bundle()
@@ -418,7 +479,11 @@ class BundleParserTest(TestCase):
         imported_molecular_tumor_board_recommendation = (
             imported_molecular_tumor_board.therapeutic_recommendations.first()
         )
-        # Check nested resources
+        self.assertIsNotNone(
+            imported_molecular_tumor_board_recommendation.events.filter(
+                pgh_label="import"
+            ).first()
+        )
 
     def test_import_bundle__case_history(self):
         self._import_bundle()

--- a/server/onconova/tests/interoperability/test_interoperability_import.py
+++ b/server/onconova/tests/interoperability/test_interoperability_import.py
@@ -520,3 +520,41 @@ class BundleParserTest(TestCase):
                 event.pgh_context["username"],
             )
             self.assertEqual(original_event.pgh_created_at, event.pgh_created_at)
+
+    def test_import_bundle__forward_reference(self):
+        """Import succeeds even when a referencing resource appears before the referenced one in the bundle."""
+        bundle = self.bundle.model_copy(deep=True)
+        # Reverse the list so the metastatic entity (which has relatedPrimaryId) comes first,
+        # creating a forward reference to a resource not yet imported.
+        bundle.neoplasticEntities = list(reversed(bundle.neoplasticEntities))
+
+        parser = BundleParser(bundle)
+        with pghistory.context(username=self.importing_user.username):
+            imported_case = parser.import_bundle()
+
+        primary = models.NeoplasticEntity.objects.get(
+            case=imported_case, relationship="primary"
+        )
+        secondary = models.NeoplasticEntity.objects.get(
+            case=imported_case, relationship="metastatic"
+        )
+        self.assertEqual(secondary.related_primary, primary)
+
+    def test_import_bundle__missing_reference_raises_descriptive_error(self):
+        """Import raises a clear, actionable ValueError when a referenced ID is absent from the bundle."""
+        import uuid
+
+        bundle = self.bundle.model_copy(deep=True)
+        # Replace the metastatic entity's relatedPrimaryId with a UUID not present in the bundle
+        secondary = next(
+            e for e in bundle.neoplasticEntities if e.relatedPrimaryId is not None
+        )
+        nonexistent_id = str(uuid.uuid4())
+        secondary.relatedPrimaryId = nonexistent_id
+
+        parser = BundleParser(bundle)
+        with self.assertRaises(ValueError) as ctx:
+            parser.import_bundle()
+
+        self.assertIn(str(nonexistent_id), str(ctx.exception))
+        self.assertIn("unresolved references", str(ctx.exception))


### PR DESCRIPTION
### Fixed

- Fixed bundle ID resolution during import to be order-independent, preventing failures when referenced bundles appear later in the import file. Fixes #213
- Fixed therapy lines not being updated when importing a bundle, ensuring treatment history remains consistent after bundle imports. Fixes #211 
- Fixed events of specialized polymorphic instances not being returned by the API, ensuring subtype-specific resources are correctly surfaced. Fixes #210