### PR TITLE
Improve case import error handling, fix elevated cohort creation, and fix cohort name edit submission

### DIFF
--- a/client/src/app/features/cases/case-importer/case-importer.component.html
+++ b/client/src/app/features/cases/case-importer/case-importer.component.html
@@ -177,8 +177,31 @@
                             <label class="form-label ml-2 my-auto required">I hereby confirm that I have the legal and ethical authorization to access and utilize this patient’s clinical data for research purposes in compliance with all applicable laws, regulations, and institutional policies.</label>
                         </div>
                     </div>
+                    @if (importError) {
+                        <p-message styleClass="my-3 w-full" severity="error" icon="pi pi-times-circle">
+                            @if (importError['detail']) {
+                                @if (isValidationErrorArray(importError['detail'])) {
+                                    <ul class="m-0 pl-3">
+                                        @for (err of importError['detail']; track $index) {
+                                            <li>
+                                                <strong>{{ formatErrorLoc(err.loc) }}</strong>: {{ err.msg }}
+                                            </li>
+                                        }
+                                    </ul>
+                                } @else {
+                                    <span>{{ importError['detail'] }}</span>
+                                }
+                            } @else {
+                                <ul class="m-0 pl-3">
+                                    @for (entry of importError | keyvalue; track entry.key) {
+                                        <li><strong>{{ entry.key }}</strong>: {{ formatErrorValue(entry.value) }}</li>
+                                    }
+                                </ul>
+                            }
+                        </p-message>
+                    }
                     <div class="flex pt-4 justify-start gap-2">
-                        <p-button label="Back" severity="secondary" icon="pi pi-arrow-left" (onClick)="activateCallback(3)" />
+                        <p-button label="Back" severity="secondary" icon="pi pi-arrow-left" (onClick)="importError = null; activateCallback(3)" />
                         <p-button label="Import case" styleClass="w-15rem" [disabled]="!consentValid || importLoading"  icon="pi pi-cloud-upload" iconPos="right" (onClick)="onImportBundle()"/>
                     </div>
                 </ng-template>

--- a/client/src/app/features/cases/case-importer/case-importer.component.ts
+++ b/client/src/app/features/cases/case-importer/case-importer.component.ts
@@ -66,6 +66,7 @@ export class CaseImporterComponent {
         // { label: 'FHIR JSON', value: 'fhir+json'  }
     ];
     public conflictResolution!: string;
+    public importError: Record<string, any> | null = null;
 
     
     onFileChange(event: any): void {
@@ -120,7 +121,8 @@ export class CaseImporterComponent {
     }
 
     onImportBundle() {
-        this.importLoading = true
+        this.importLoading = true;
+        this.importError = null;
         this.interoperabilityService.importPatientCaseBundle({patientCaseBundle: this.bundle!, conflict: this.conflictResolution}).subscribe({
             next: (response) => {
                 this.messageService.add({ severity: 'success', summary: 'Import', detail: 'Succesfully imported the file' });
@@ -131,10 +133,24 @@ export class CaseImporterComponent {
                 });
             },
             error: (error: any) => {
-                this.messageService.add({ severity: 'error', summary: 'Error', detail: error.error.detail });
+                this.importError = error.error ?? { detail: 'An unexpected error occurred during import.' };
                 this.importLoading = false;
             },
         })    
+    }
+
+    isValidationErrorArray(detail: any): boolean {
+        return Array.isArray(detail) && detail.length > 0 && typeof detail[0] === 'object' && 'msg' in detail[0];
+    }
+
+    formatErrorLoc(loc: any[]): string {
+        return loc.filter(s => s !== 'body').join(' → ');
+    }
+
+    formatErrorValue(value: any): string {
+        if (Array.isArray(value)) return value.join(' ');
+        if (typeof value === 'object' && value !== null) return JSON.stringify(value);
+        return String(value);
     }
 
     private constructBundleTree(bundle: PatientCaseBundle): TreeNode[] {

--- a/client/src/app/features/cohorts/cohort-manager/cohort-manager.component.html
+++ b/client/src/app/features/cohorts/cohort-manager/cohort-manager.component.html
@@ -14,7 +14,7 @@
                                 icon="pi pi-check"
                                 variant="text"
                                 [disabled]="!userCanEdit()"
-                                (onClick)="editCohortName = false"/>
+                                (onClick)="editCohortName = false; submitCohort()"/>
                         } @else {
                             @if ( cohortTitle() ) {
                                 {{ cohortTitle() }}

--- a/client/src/app/features/forms/cohort-form/cohort-form.component.ts
+++ b/client/src/app/features/forms/cohort-form/cohort-form.component.ts
@@ -7,7 +7,7 @@ import { ToggleSwitch } from 'primeng/toggleswitch';
 import { Fluid } from 'primeng/fluid';
 import { InputText } from 'primeng/inputtext';
 
-import { CohortCreate, Cohort, CohortsService, ProjectsService, GetProjectsRequestParams } from 'onconova-api-client'
+import { CohortCreate, Cohort, CohortsService, ProjectsService, GetProjectsRequestParams, AccessRoles } from 'onconova-api-client'
 
 import { AbstractFormBase } from '../abstract-form-base.component';
 import { 
@@ -46,7 +46,7 @@ export class CohortFormComponent extends AbstractFormBase {
   readonly #fb = inject(FormBuilder);
 
   #currentUser = computed(() => this.#authService.user());
-  protected invalidUser = computed(() => this.relatedProjects.hasValue() && this.relatedProjects.value().length === 0)
+  protected invalidUser = computed(() => this.relatedProjects.hasValue() && this.relatedProjects.value().length === 0);
   // Create and update service methods for the form data
   public readonly createService = (payload: CohortCreate) => this.#cohortsService.createCohort({cohortCreate: payload});
   public readonly updateService = (id: string, payload: CohortCreate) => this.#cohortsService.updateCohort({cohortId: id, cohortCreate: payload});
@@ -69,7 +69,9 @@ export class CohortFormComponent extends AbstractFormBase {
   }
 
   protected relatedProjects = rxResource({
-    request: () => ({membersUsername: this.#currentUser()?.username, status: 'ongoing'} as GetProjectsRequestParams),
+    request: () => (
+      (this.#currentUser().role !== AccessRoles.PlatformManager && this.#currentUser().role !== AccessRoles.SystemAdministrator) ? {membersUsername: this.#currentUser()?.username, status: 'ongoing'} as GetProjectsRequestParams : {} as GetProjectsRequestParams
+    ),
     loader: ({request}) => this.#projectsService.getProjects(request).pipe(
       map(response => response.items)
     )


### PR DESCRIPTION

### Added
- Added structured error handling and validation feedback for case import. Fixes #196

### Fixed 
 - Ensure that platform and system administrators can create cohorts for any project. Fixes #182
 - Clicking the confirm button after editing a cohort name now calls `submitCohort()` in addition to closing the edit input, ensuring the name change is persisted.  Fixes #183
